### PR TITLE
 feat(updater): sanitize release notes, re-show remind-later prompt on restart, add download progress bar

### DIFF
--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -25,8 +25,7 @@ function getUserDataPaths() {
     userData,
     myGamesPath: path.join(userData, 'myGames.json'),
     gameListPath: path.join(userData, 'gamelist.json'),
-    gamesRoot: path.join(userData, 'games'),
-    updateStatePath: path.join(userData, 'updateState.json')
+    gamesRoot: path.join(userData, 'games')
   };
 }
 
@@ -301,17 +300,6 @@ let runningProc = null;
 
 let pendingUpdateInfo = null;
 
-async function readUpdateState() {
-  const paths = getUserDataPaths();
-  return await readJsonIfExists(paths.updateStatePath, { dismissedVersion: null, dismissedAt: null });
-}
-
-async function writeUpdateState(state) {
-  const paths = getUserDataPaths();
-  ensureDirSync(paths.userData);
-  await writeJson(paths.updateStatePath, state);
-}
-
 function coerceReleaseNotesToText(releaseNotes) {
   if (!releaseNotes) return '';
 
@@ -339,16 +327,9 @@ async function maybeCheckForUpdates() {
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;
 
-  autoUpdater.on('update-available', async (info) => {
-    try {
-      const state = await readUpdateState();
-      if (state?.dismissedVersion && String(state.dismissedVersion) === String(info?.version || '')) {
-        return; // user chose "remind later" for this version
-      }
-    } catch {
-      // ignore
-    }
-
+  autoUpdater.on('update-available', (info) => {
+    // No persisted dismissal: if the user picks "remind later", the update
+    // prompt will simply reappear the next time the app starts and checks.
     pendingUpdateInfo = info;
     const payload = {
       version: String(info?.version || ''),
@@ -366,6 +347,15 @@ async function maybeCheckForUpdates() {
 
   autoUpdater.on('error', (err) => {
     mainWindow?.webContents.send('update/error', { message: String(err?.message || err || 'Unknown error') });
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    mainWindow?.webContents.send('update/progress', {
+      percent: Number(progress?.percent) || 0,
+      transferred: Number(progress?.transferred) || 0,
+      total: Number(progress?.total) || 0,
+      bytesPerSecond: Number(progress?.bytesPerSecond) || 0
+    });
   });
 
   autoUpdater.on('update-downloaded', () => {
@@ -624,8 +614,8 @@ ipcMain.handle('launcher/stopGame', async () => {
 // Updates
 // ───────────────────────────────────────────────────────────
 ipcMain.handle('update/remindLater', async () => {
-  const v = String(pendingUpdateInfo?.version || '');
-  await writeUpdateState({ dismissedVersion: v || null, dismissedAt: new Date().toISOString() });
+  // Intentionally not persisted: the update prompt will show again on the
+  // next app startup since nothing is written to disk here.
   pendingUpdateInfo = null;
   return { ok: true };
 });
@@ -634,9 +624,6 @@ ipcMain.handle('update/install', async () => {
   if (!app.isPackaged) return { ok: false, error: 'Updates are only available in packaged builds.' };
 
   try {
-    // Clear any previous dismiss state so the same version doesn't get suppressed.
-    await writeUpdateState({ dismissedVersion: null, dismissedAt: null });
-
     await autoUpdater.downloadUpdate();
 
     // When update-downloaded fires, renderer can call quitAndInstall.

--- a/electron/src/preload.js
+++ b/electron/src/preload.js
@@ -33,6 +33,10 @@ contextBridge.exposeInMainWorld('launcherApi', {
     ipcRenderer.removeAllListeners('update/available');
     ipcRenderer.on('update/available', (_evt, payload) => handler(payload));
   },
+  onUpdateProgress: (handler) => {
+    ipcRenderer.removeAllListeners('update/progress');
+    ipcRenderer.on('update/progress', (_evt, payload) => handler(payload));
+  },
   onUpdateDownloaded: (handler) => {
     ipcRenderer.removeAllListeners('update/downloaded');
     ipcRenderer.on('update/downloaded', handler);

--- a/electron/src/renderer/index.html
+++ b/electron/src/renderer/index.html
@@ -113,7 +113,13 @@
       </div>
       <div class="modal-body">
         <div style="color: var(--text-muted); font-weight: 600; margin-bottom: 10px;" id="updateSubtitle"></div>
-        <div class="modal-list" style="padding: 12px; overflow: auto; font-family: Consolas, monospace; font-size: 12px; color: var(--text-normal);" id="updateNotes"></div>
+        <div class="modal-list update-notes" id="updateNotes"></div>
+        <div class="update-progress-wrap" id="updateProgressWrap" style="display:none;">
+          <div class="update-progress-bar">
+            <div class="update-progress-fill" id="updateProgressFill"></div>
+          </div>
+          <div class="update-progress-text" id="updateProgressText">Downloading update…</div>
+        </div>
         <div style="display:flex; gap:10px; justify-content:flex-end; margin-top: 12px;">
           <button class="btn-add-game" id="updateRemindBtn" style="width:auto; padding:10px 14px;">Remind me later</button>
           <button class="btn-main" id="updateInstallBtn" style="height:auto; padding:10px 18px;">Install update</button>

--- a/electron/src/renderer/renderer.js
+++ b/electron/src/renderer/renderer.js
@@ -37,6 +37,9 @@ const updateSubtitle = document.getElementById('updateSubtitle');
 const updateNotes = document.getElementById('updateNotes');
 const updateInstallBtn = document.getElementById('updateInstallBtn');
 const updateRemindBtn = document.getElementById('updateRemindBtn');
+const updateProgressWrap = document.getElementById('updateProgressWrap');
+const updateProgressFill = document.getElementById('updateProgressFill');
+const updateProgressText = document.getElementById('updateProgressText');
 
 // Details panel
 const detailAppId = document.getElementById('detailAppId');
@@ -261,10 +264,13 @@ function showUpdateModal(payload) {
     ? `${version} — ${payload.releaseName}`
     : version;
 
-  const notesText = (payload.releaseNotes && String(payload.releaseNotes).trim())
-    ? String(payload.releaseNotes)
-    : 'No release notes provided.';
-  updateNotes.textContent = notesText;
+  updateNotes.innerHTML = renderReleaseNotesHtml(payload.releaseNotes);
+
+  if (updateProgressWrap) {
+    updateProgressWrap.style.display = 'none';
+    updateProgressFill.style.width = '0%';
+    updateProgressText.textContent = 'Downloading update…';
+  }
 
   updateModal.style.display = 'flex';
 }
@@ -274,6 +280,105 @@ function hideUpdateModal() {
   updateUiState.installing = false;
   updateModal.style.display = 'none';
 }
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(1)} MB`;
+}
+
+function setUpdateProgress(percent, payload) {
+  if (!updateProgressWrap) return;
+  updateProgressWrap.style.display = 'block';
+
+  const pct = Math.max(0, Math.min(100, Math.round(percent)));
+  updateProgressFill.style.width = `${pct}%`;
+
+  if (payload && Number.isFinite(payload.total) && payload.total > 0) {
+    const speed = payload.bytesPerSecond ? ` — ${formatBytes(payload.bytesPerSecond)}/s` : '';
+    updateProgressText.textContent =
+      `Downloading update… ${pct}% (${formatBytes(payload.transferred)} / ${formatBytes(payload.total)})${speed}`;
+  } else {
+    updateProgressText.textContent = `Downloading update… ${pct}%`;
+  }
+}
+
+// --- RELEASE NOTES SANITIZER/RENDERER ---
+// GitHub release notes arrive as HTML (markdown already converted upstream).
+// We only allow a small whitelist of formatting tags and strip everything
+// else (including <img> tags entirely, per design) to avoid XSS and to keep
+// the rendered notes looking like the GitHub release page.
+const RELEASE_NOTES_ALLOWED_TAGS = new Set([
+  'P', 'BR', 'STRONG', 'B', 'EM', 'I', 'U', 'S',
+  'UL', 'OL', 'LI', 'A', 'CODE', 'PRE', 'BLOCKQUOTE',
+  'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HR', 'SPAN'
+]);
+const RELEASE_NOTES_DROP_TAGS = new Set([
+  'IMG', 'SCRIPT', 'STYLE', 'IFRAME', 'OBJECT', 'EMBED',
+  'VIDEO', 'AUDIO', 'SVG', 'LINK', 'META', 'FORM', 'INPUT', 'BUTTON'
+]);
+const RELEASE_NOTES_SAFE_URL_RE = /^(https?:|mailto:)/i;
+
+function sanitizeReleaseNotesNode(node) {
+  const children = Array.from(node.childNodes);
+  for (const child of children) {
+    if (child.nodeType === Node.COMMENT_NODE) {
+      child.remove();
+      continue;
+    }
+    if (child.nodeType !== Node.ELEMENT_NODE) continue;
+
+    const tag = child.tagName;
+
+    if (RELEASE_NOTES_DROP_TAGS.has(tag)) {
+      child.remove();
+      continue;
+    }
+
+    for (const attr of Array.from(child.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (tag === 'A' && name === 'href') {
+        if (!RELEASE_NOTES_SAFE_URL_RE.test(attr.value.trim())) child.removeAttribute(attr.name);
+        continue;
+      }
+      child.removeAttribute(attr.name);
+    }
+
+    if (tag === 'A') {
+      child.setAttribute('target', '_blank');
+      child.setAttribute('rel', 'noopener noreferrer');
+    }
+
+    if (!RELEASE_NOTES_ALLOWED_TAGS.has(tag)) {
+      sanitizeReleaseNotesNode(child);
+      while (child.firstChild) node.insertBefore(child.firstChild, child);
+      child.remove();
+      continue;
+    }
+
+    sanitizeReleaseNotesNode(child);
+  }
+}
+
+function renderReleaseNotesHtml(rawNotes) {
+  const text = String(rawNotes || '').trim();
+  if (!text) return '<p style="color:var(--text-muted);">No release notes provided.</p>';
+
+  // Plain text (no HTML tags) - escape and preserve line breaks.
+  if (!/<[a-z!/][\s\S]*>/i.test(text)) {
+    const escapeDiv = document.createElement('div');
+    escapeDiv.textContent = text;
+    return `<p>${escapeDiv.innerHTML.replace(/\n/g, '<br>')}</p>`;
+  }
+
+  const doc = new DOMParser().parseFromString(`<div id="release-notes-root">${text}</div>`, 'text/html');
+  const root = doc.getElementById('release-notes-root');
+  if (!root) return '';
+
+  sanitizeReleaseNotesNode(root);
+  return root.innerHTML;
+}
+// ------------------------------------------
 
 function debounce(fn, waitMs) {
   let t = null;
@@ -491,6 +596,7 @@ if (updateInstallBtn) {
     updateInstallBtn.disabled = true;
     updateRemindBtn.disabled = true;
     updateInstallBtn.textContent = 'Downloading…';
+    setUpdateProgress(0, null);
 
     const r = await launcherApi.installUpdate();
     if (!r?.ok) {
@@ -499,6 +605,7 @@ if (updateInstallBtn) {
       updateInstallBtn.disabled = false;
       updateRemindBtn.disabled = false;
       updateInstallBtn.textContent = 'Install update';
+      if (updateProgressWrap) updateProgressWrap.style.display = 'none';
     }
   });
 }
@@ -529,9 +636,18 @@ launcherApi.onGameExited(() => {
       log('Update available.', 'log-success');
     });
   }
+  if (launcherApi.onUpdateProgress) {
+    launcherApi.onUpdateProgress((payload) => {
+      setUpdateProgress(payload?.percent || 0, payload);
+    });
+  }
   if (launcherApi.onUpdateDownloaded) {
     launcherApi.onUpdateDownloaded(async () => {
-      // Install immediately once downloaded
+      setUpdateProgress(100, null);
+      if (updateProgressText) updateProgressText.textContent = 'Download complete. Installing…';
+      if (updateInstallBtn) updateInstallBtn.textContent = 'Installing…';
+      log('Update downloaded. Installing…', 'log-success');
+      // Opens the downloaded installer and quits this app so it can run.
       await launcherApi.quitAndInstallUpdate();
     });
   }

--- a/electron/src/renderer/styles.css
+++ b/electron/src/renderer/styles.css
@@ -456,4 +456,103 @@ body {
 ::-webkit-scrollbar-track { background-color: rgba(0,0,0,0.1); }
 ::-webkit-scrollbar-thumb { background-color: var(--bg-darkest); border-radius: 10px; }
 
+/* --- Update modal release notes --- */
+.update-notes {
+  padding: 12px 14px;
+  overflow: auto;
+  max-height: 320px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-normal);
+}
+
+.update-notes h1,
+.update-notes h2,
+.update-notes h3,
+.update-notes h4 {
+  color: var(--text-header);
+  font-weight: 700;
+  margin: 14px 0 8px;
+  line-height: 1.3;
+}
+
+.update-notes h1:first-child,
+.update-notes h2:first-child,
+.update-notes h3:first-child,
+.update-notes h4:first-child,
+.update-notes p:first-child {
+  margin-top: 0;
+}
+
+.update-notes p { margin: 8px 0; }
+
+.update-notes ul,
+.update-notes ol {
+  margin: 8px 0;
+  padding-left: 22px;
+}
+
+.update-notes li { margin: 4px 0; }
+
+.update-notes a {
+  color: var(--brand);
+  text-decoration: none;
+}
+
+.update-notes a:hover { text-decoration: underline; }
+
+.update-notes code {
+  background-color: rgba(0,0,0,0.3);
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-family: Consolas, monospace;
+  font-size: 12px;
+}
+
+.update-notes pre {
+  background-color: rgba(0,0,0,0.3);
+  padding: 10px;
+  border-radius: 6px;
+  overflow: auto;
+}
+
+.update-notes pre code { background: none; padding: 0; }
+
+.update-notes blockquote {
+  border-left: 3px solid var(--brand);
+  margin: 8px 0;
+  padding-left: 12px;
+  color: var(--text-muted);
+}
+
+.update-notes hr {
+  border: none;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  margin: 14px 0;
+}
+
+/* --- Update progress bar --- */
+.update-progress-wrap { margin-top: 14px; }
+
+.update-progress-bar {
+  width: 100%;
+  height: 8px;
+  background-color: var(--bg-card);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.update-progress-fill {
+  height: 100%;
+  width: 0%;
+  background-color: var(--brand);
+  transition: width 0.15s ease-out;
+}
+
+.update-progress-text {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }


### PR DESCRIPTION
Improves the update-checker UX: release notes now render properly, "Remind me later" no longer permanently suppresses the prompt, and the install flow shows real download progress before launching the installer.