### PR TITLE
feat(mac): add native macOS support (cross-platform Windows & macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,22 @@ dotnet build ./src/DummyGame/DummyGame.csproj -c Release
    ```
 
 The installer will be created in `electron/dist/`.
+
+### Building on macOS
+
+On macOS, you only need Node.js and standard Xcode Command Line Tools (`clang`).
+
+1. **Build and Package for macOS**:
+   ```bash
+   cd electron
+   npm install
+   npm run dist:mac
+   ```
+
+   The `.app` bundle and installer will be generated in `electron/dist/`.
+
+2. **Run on macOS**:
+   ```bash
+   ./run_on_mac.sh
+   ```
+

--- a/electron/package.json
+++ b/electron/package.json
@@ -14,9 +14,14 @@
     "sync:gamelist": "node ./scripts/sync-gamelist.js",
     "build:dummy": "dotnet build ../src/DummyGame/DummyGame.csproj -c Release",
     "build:launcher": "dotnet build ../src/Launcher/Launcher.csproj -c Release",
+    "build:dummy:mac": "node ./scripts/build-dummy-mac.js",
     "dist": "electron-builder --win nsis --publish never",
     "dist:portable": "electron-builder --win portable --publish never",
-    "dist:publish": "electron-builder --win nsis --publish always"
+    "dist:publish": "electron-builder --win nsis --publish always",
+    "dist:mac": "npm run build:dummy:mac && electron-builder --mac --publish never",
+    "dist:mac:dmg": "npm run build:dummy:mac && electron-builder --mac dmg --publish never",
+    "dist:mac:dir": "npm run build:dummy:mac && electron-builder --mac --dir --publish never",
+    "build:mac": "npm run dist:mac"
   },
   "devDependencies": {
     "electron": "^30.0.0",

--- a/electron/scripts/build-dummy-mac.js
+++ b/electron/scripts/build-dummy-mac.js
@@ -1,0 +1,44 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function main() {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const sourcePath = path.join(repoRoot, 'src', 'DummyGame', 'DummyGame_mac.m');
+  const targetResourceDir = path.resolve(__dirname, '..', 'build-resources', 'dummygame');
+  const targetExe = path.join(targetResourceDir, 'DummyGame.exe');
+
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Source file not found: ${sourcePath}`);
+  }
+
+  if (!fs.existsSync(targetResourceDir)) {
+    fs.mkdirSync(targetResourceDir, { recursive: true });
+  }
+
+  console.log(`Compiling macOS DummyGame universal binary from ${sourcePath}...`);
+
+  // Compile universal binary (arm64 + x86_64) using clang with Cocoa framework
+  const cmd = `clang -arch arm64 -arch x86_64 -fobjc-arc -framework Cocoa -O2 "${sourcePath}" -o "${targetExe}"`;
+  execSync(cmd, { stdio: 'inherit' });
+
+  // Ensure executable permissions
+  fs.chmodSync(targetExe, 0o755);
+
+  // Also create extensionless DummyGame for macOS
+  const targetBin = path.join(targetResourceDir, 'DummyGame');
+  fs.copyFileSync(targetExe, targetBin);
+  fs.chmodSync(targetBin, 0o755);
+
+  // Also copy to dev-mode fallback path: src/DummyGame/bin/Release/net8.0-windows/
+  const devFallbackDir = path.join(repoRoot, 'src', 'DummyGame', 'bin', 'Release', 'net8.0-windows');
+  fs.mkdirSync(devFallbackDir, { recursive: true });
+  fs.copyFileSync(targetExe, path.join(devFallbackDir, 'DummyGame.exe'));
+  fs.chmodSync(path.join(devFallbackDir, 'DummyGame.exe'), 0o755);
+  fs.copyFileSync(targetExe, path.join(devFallbackDir, 'DummyGame'));
+  fs.chmodSync(path.join(devFallbackDir, 'DummyGame'), 0o755);
+
+  console.log(`Successfully built DummyGame for macOS at: ${targetBin} and ${targetExe}`);
+}
+
+main();

--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -45,6 +45,9 @@ function fallbackExeNameFromTitle(name) {
     .slice(0, 120);
 
   const safeBase = base || 'Game';
+  if (process.platform === 'darwin') {
+    return safeBase.replace(/\.exe$/i, '');
+  }
   return safeBase.toLowerCase().endsWith('.exe') ? safeBase : `${safeBase}.exe`;
 }
 
@@ -73,7 +76,10 @@ function toDatabaseGames(detectableApps) {
     const bestExe = pickBestExecutable(appEntry);
 
     const appId = String(appEntry.id || '');
-    const exeName = bestExe?.name ? String(bestExe.name) : fallbackExeNameFromTitle(appEntry.name);
+    let exeName = bestExe?.name ? String(bestExe.name) : fallbackExeNameFromTitle(appEntry.name);
+    if (process.platform === 'darwin') {
+      exeName = exeName.replace(/\.exe$/i, '');
+    }
 
     result.push({
       id: appId,
@@ -207,9 +213,21 @@ async function findDummyGameTemplate() {
 
   // Packaged build: bundled via electron-builder extraResources
   if (app.isPackaged) {
+    if (process.platform === 'darwin') {
+      const bundledMac = path.join(process.resourcesPath, 'dummygame', 'DummyGame');
+      if (fs.existsSync(bundledMac)) return bundledMac;
+    }
     const bundled = path.join(process.resourcesPath, 'dummygame', 'DummyGame.exe');
     if (fs.existsSync(bundled)) return bundled;
   }
+
+  // Local build cache fallback (dev/local builds): ../build-resources/dummygame/DummyGame[.exe]
+  if (process.platform === 'darwin') {
+    const localResourceMac = path.join(__dirname, '..', 'build-resources', 'dummygame', 'DummyGame');
+    if (fs.existsSync(localResourceMac)) return localResourceMac;
+  }
+  const localResource = path.join(__dirname, '..', 'build-resources', 'dummygame', 'DummyGame.exe');
+  if (fs.existsSync(localResource)) return localResource;
 
   // Repo-relative fallback (dev): ../src/DummyGame/bin/**/DummyGame.exe
   const repoRoot = path.resolve(app.getAppPath(), '..', '..');
@@ -222,6 +240,9 @@ async function findDummyGameTemplate() {
   for (const cfg of configs) {
     candidates.push(path.join(dummyProjBin, cfg, 'net8.0-windows', 'DummyGame.exe'));
     candidates.push(path.join(dummyProjBin, cfg, 'net8.0-windows7.0', 'DummyGame.exe'));
+    if (process.platform === 'darwin') {
+      candidates.push(path.join(dummyProjBin, cfg, 'net8.0-windows', 'DummyGame'));
+    }
   }
 
   for (const c of candidates) {
@@ -244,7 +265,7 @@ async function findDummyGameTemplate() {
         // avoid huge recursion
         if (p.toLowerCase().includes('ref')) continue;
         stack.push(p);
-      } else if (e.isFile() && e.name.toLowerCase() === 'dummygame.exe') {
+      } else if (e.isFile() && (e.name.toLowerCase() === 'dummygame.exe' || (process.platform === 'darwin' && e.name === 'DummyGame'))) {
         return p;
       }
     }
@@ -256,7 +277,7 @@ async function findDummyGameTemplate() {
 async function ensureFakeExeForGame(game, paths) {
   const dummySourceExe = await findDummyGameTemplate();
   if (!dummySourceExe) {
-    throw new Error('Could not find DummyGame.exe. Run: npm run build:dummy (from electron/), or set DUMMYGAME_EXE env var to the built DummyGame.exe path.');
+    throw new Error('Could not find DummyGame. Run: npm run build:dummy:mac (from electron/), or set DUMMYGAME_EXE env var.');
   }
 
   ensureDirSync(paths.gamesRoot);
@@ -265,16 +286,28 @@ async function ensureFakeExeForGame(game, paths) {
 
   const exeRelPath = normalizeExeRelPath(game.exe);
   const exeFolderPart = path.dirname(exeRelPath) === '.' ? '' : path.dirname(exeRelPath);
-  const exeFileName = path.basename(exeRelPath);
+  let exeFileName = path.basename(exeRelPath);
+
+  if (process.platform === 'darwin') {
+    exeFileName = exeFileName.replace(/\.exe$/i, '') || sanitizeFolderName(game.name) || 'Game';
+  }
 
   const gameFolder = path.join(paths.gamesRoot, appIdFolder, exeFolderPart);
   ensureDirSync(gameFolder);
 
   const destExePath = path.join(gameFolder, exeFileName);
 
+  // If on macOS and an old .exe exists, clean it up
+  if (process.platform === 'darwin' && fs.existsSync(destExePath + '.exe')) {
+    try { await fsp.unlink(destExePath + '.exe'); } catch {}
+  }
+
   if (!fs.existsSync(destExePath)) {
     // Copy main exe but rename to target exe file name
     await fsp.copyFile(dummySourceExe, destExePath);
+    if (process.platform !== 'win32') {
+      try { await fsp.chmod(destExePath, 0o755); } catch {}
+    }
 
     // Copy sidecar files DummyGame.* from source dir
     const sourceDir = path.dirname(dummySourceExe);
@@ -289,8 +322,13 @@ async function ensureFakeExeForGame(game, paths) {
       const dest = path.join(gameFolder, fileName);
       if (!fs.existsSync(dest)) {
         await fsp.copyFile(src, dest);
+        if (process.platform !== 'win32') {
+          try { await fsp.chmod(dest, 0o755); } catch {}
+        }
       }
     }
+  } else if (process.platform !== 'win32') {
+    try { await fsp.chmod(destExePath, 0o755); } catch {}
   }
 
   return { destExePath, workingDirectory: path.dirname(destExePath) };
@@ -322,8 +360,8 @@ function coerceReleaseNotesToText(releaseNotes) {
 }
 
 async function maybeCheckForUpdates() {
-  // Updates only make sense in packaged builds.
-  if (!app.isPackaged) return;
+  // Updates only make sense in packaged builds on Windows (upstream GitHub releases are Windows-only).
+  if (!app.isPackaged || process.platform !== 'win32') return;
 
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;
@@ -437,13 +475,17 @@ ipcMain.handle('launcher/getMyGames', async () => {
   const list = await readJsonIfExists(paths.myGamesPath, []);
   const safeList = Array.isArray(list) ? list : [];
 
-  // Privacy/safety: remove any persisted artwork fields from older versions.
+  // Privacy/safety: remove any persisted artwork fields from older versions, and strip .exe on macOS
   let changed = false;
   for (const g of safeList) {
     if (g && typeof g === 'object') {
       if (Object.prototype.hasOwnProperty.call(g, 'icon')) { delete g.icon; changed = true; }
       if (Object.prototype.hasOwnProperty.call(g, 'thumbnail')) { delete g.thumbnail; changed = true; }
       if (Object.prototype.hasOwnProperty.call(g, 'igdbId')) { delete g.igdbId; changed = true; }
+      if (process.platform === 'darwin' && typeof g.exe === 'string' && g.exe.toLowerCase().endsWith('.exe')) {
+        g.exe = g.exe.replace(/\.exe$/i, '');
+        changed = true;
+      }
     }
   }
   if (changed) {
@@ -460,10 +502,15 @@ ipcMain.handle('launcher/addGame', async (_evt, game) => {
   const myGames = await readJsonIfExists(paths.myGamesPath, []);
   const safeList = Array.isArray(myGames) ? myGames : [];
 
+  let exeName = String(game?.exe || '');
+  if (process.platform === 'darwin') {
+    exeName = exeName.replace(/\.exe$/i, '') || sanitizeFolderName(game?.name) || 'Game';
+  }
+
   const entry = {
-    appId: String(game?.id || ''),
+    appId: String(game?.id || game?.appId || ''),
     name: String(game?.name || 'Game'),
-    exe: String(game?.exe || ''),
+    exe: exeName,
     isFavorite: false
   };
 
@@ -483,9 +530,11 @@ ipcMain.handle('launcher/toggleFavorite', async (_evt, { appId, exe }) => {
   const myGames = await readJsonIfExists(paths.myGamesPath, []);
   const safeList = Array.isArray(myGames) ? myGames : [];
 
+  const norm = (v) => process.platform === 'darwin' ? String(v || '').replace(/\.exe$/i, '') : String(v || '');
+
   let updated = null;
   for (const g of safeList) {
-    if (String(g?.appId || '') === String(appId || '') && String(g?.exe || '') === String(exe || '')) {
+    if (String(g?.appId || '') === String(appId || '') && norm(g?.exe) === norm(exe)) {
       g.isFavorite = !g.isFavorite;
       updated = g;
       break;
@@ -501,10 +550,12 @@ ipcMain.handle('launcher/deleteGame', async (_evt, { appId, exe }) => {
   const myGames = await readJsonIfExists(paths.myGamesPath, []);
   const safeList = Array.isArray(myGames) ? myGames : [];
 
+  const norm = (v) => process.platform === 'darwin' ? String(v || '').replace(/\.exe$/i, '') : String(v || '');
+
   const before = safeList.length;
   const filtered = safeList.filter(g => !(
     String(g?.appId || '') === String(appId || '') &&
-    String(g?.exe || '') === String(exe || '')
+    norm(g?.exe) === norm(exe)
   ));
 
   if (filtered.length !== before) {

--- a/electron/src/renderer/renderer.js
+++ b/electron/src/renderer/renderer.js
@@ -674,9 +674,12 @@ launcherApi.onGameExited((payload = {}) => {
 });
 
 (async function init() {
-  await ensureDatabaseSynced();
+  // Load local library immediately so the UI is instantly ready
   await refreshMyGames();
   renderMainList('');
+
+  // Sync Discord database in background
+  ensureDatabaseSynced();
 
   // Update notifications
   if (launcherApi.onUpdateAvailable) {

--- a/run_on_mac.sh
+++ b/run_on_mac.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+open "$DIR/electron/dist/mac-arm64/Discord Fake Game Launcher.app"

--- a/src/DummyGame/DummyGame_mac.m
+++ b/src/DummyGame/DummyGame_mac.m
@@ -1,0 +1,60 @@
+#import <Cocoa/Cocoa.h>
+
+@interface DummyAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@property (strong) NSWindow *window;
+@end
+
+@implementation DummyAppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    NSString *displayName = (args.count > 1 && [args[1] length] > 0) ? args[1] : @"Game";
+
+    // Set macOS process name without .exe so Discord detects the game and its official icon
+    [[NSProcessInfo processInfo] setProcessName:displayName];
+
+    NSRect frame = NSMakeRect(0, 0, 480, 200);
+    NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
+
+    self.window = [[NSWindow alloc] initWithContentRect:frame
+                                              styleMask:style
+                                                backing:NSBackingStoreBuffered
+                                                  defer:NO];
+    [self.window setTitle:displayName];
+    [self.window setDelegate:self];
+    [self.window center];
+
+    NSTextField *label = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 75, 440, 40)];
+    [label setStringValue:[NSString stringWithFormat:@"%@ (fake process for Discord)", displayName]];
+    [label setAlignment:NSTextAlignmentCenter];
+    [label setBezeled:NO];
+    [label setDrawsBackground:NO];
+    [label setEditable:NO];
+    [label setSelectable:NO];
+    [label setFont:[NSFont systemFontOfSize:14]];
+    [[self.window contentView] addSubview:label];
+
+    [self.window makeKeyAndOrderFront:nil];
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
+    return YES;
+}
+
+- (void)windowWillClose:(NSNotification *)notification {
+    [NSApp terminate:nil];
+}
+
+@end
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        NSApplication *app = [NSApplication sharedApplication];
+        [app setActivationPolicy:NSApplicationActivationPolicyRegular];
+        DummyAppDelegate *delegate = [[DummyAppDelegate alloc] init];
+        [app setDelegate:delegate];
+        [app run];
+    }
+    return 0;
+}


### PR DESCRIPTION
## 📌 Description
This PR introduces native **macOS support** to Discord Fake Game Launcher, allowing macOS users (both Apple Silicon and Intel) to launch dummy games and have Discord detect them, while maintaining 100% backward compatibility with Windows.

Resolves #<NOMOR_ISSUE> <!-- Ganti dengan nomor issue dari Langkah 1, misal: #15 -->

---

## 🚀 Changes Summary

### 1. Native macOS Dummy Game (`src/DummyGame/DummyGame_mac.m`)
- Built a lightweight Cocoa/Objective-C dummy process that sets `NSProcessInfo.processName` to the targeted game name.
- Creates a lightweight minimal window showing the spoofed game status.
- Automatically handles app termination when the window is closed.

### 2. macOS Build Script (`electron/scripts/build-dummy-mac.js`)
- Compiles `DummyGame_mac.m` into a universal binary (`arm64` + `x86_64`) using `clang` with `-framework Cocoa`.
- Places the compiled binary into `build-resources/dummygame/DummyGame` and dev fallback paths.

### 3. Main Process Updates (`electron/src/main.js`)
- Added platform detection (`process.platform === 'darwin'`) when locating dummy game templates.
- Automatically strips `.exe` extension on macOS for game executables (`addGame`, `getMyGames`, `deleteGame`, `toggleFavorite`).
- Ensures proper executable permissions (`chmod 0o755`) for launched dummy binaries.
- Disabled Windows-specific NSIS auto-update checks when running on macOS.

### 4. Renderer Performance Improvement (`electron/src/renderer/renderer.js`)
- UI renders local saved games immediately upon launch while database synchronization continues in the background.

### 5. Package & Build Configuration (`electron/package.json` & `README.md`)
- Added scripts:
  - `npm run build:dummy:mac`: Compiles native Cocoa dummy game.
  - `npm run dist:mac`: Builds the macOS distribution.
  - `npm run dist:mac:dmg`: Packages a macOS `.dmg` installer.
  - `npm run dist:mac:dir`: Builds an unpacked macOS `.app` bundle.
- Updated `README.md` with macOS build instructions.
- Added convenience script `run_on_mac.sh`.

---

## 🧪 How Has This Been Tested?
- [x] **macOS (Apple Silicon)**:
  - Compiled dummy binary via `npm run build:dummy:mac`.
  - Launched games from the UI and verified Discord successfully detects the activity.
  - Verified toggle favorite, delete, and search functions without `.exe` quirks.
  - Packaged macOS app (`dist:mac`) and verified standalone execution.
- [x] **Windows compatibility**:
  - Ensured Windows fallback paths and `.exe` handling remain unchanged.

---

## 📋 Checklist
- [x] Code adheres to the existing project style.
- [x] Tested locally on macOS.
- [x] No breaking changes introduced for Windows users.
